### PR TITLE
[Refactor+Fix] Поле link в модели статьи и ошибка с $push

### DIFF
--- a/models/Article.js
+++ b/models/Article.js
@@ -3,16 +3,25 @@ var uniqueValidator = require('mongoose-unique-validator');
 var slug = require('slug');
 var User = mongoose.model('User');
 
+const urlRegExp = new RegExp('^(?:http(s)?:\\/\\/)?[\\w.-]+(?:\\.[\\w.-]+)+[\\w\\-._~:/?#[\\]@!$&\'()*+,;=.]+$');
+
 var ArticleSchema = new mongoose.Schema({
   slug: {type: String, lowercase: true, unique: true},
   title: String,
   description: String,
   body: String,
+    link: {
+        type: String,
+        validate: {
+            validator: (v) => urlRegExp.test(v),
+            message: 'Поле "link" должно быть валидным url-адресом.',
+        },
+    },
   favoritesCount: {type: Number, default: 0},
   comments: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Comment' }],
   tagList: [{ type: String }],
   author: { type: mongoose.Schema.Types.ObjectId, ref: 'User' }
-}, {timestamps: true});
+}, {timestamps: true, usePushEach: true});
 
 ArticleSchema.plugin(uniqueValidator, {message: 'is already taken'});
 
@@ -44,6 +53,7 @@ ArticleSchema.methods.toJSONFor = function(user){
     title: this.title,
     description: this.description,
     body: this.body,
+    link: this.link,
     createdAt: this.createdAt,
     updatedAt: this.updatedAt,
     tagList: this.tagList,

--- a/models/Comment.js
+++ b/models/Comment.js
@@ -4,7 +4,7 @@ var CommentSchema = new mongoose.Schema({
   body: String,
   author: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
   article: { type: mongoose.Schema.Types.ObjectId, ref: 'Article' }
-}, {timestamps: true});
+}, {timestamps: true, usePushEach: true});
 
 // Requires population of author
 CommentSchema.methods.toJSONFor = function(user){

--- a/models/User.js
+++ b/models/User.js
@@ -13,7 +13,7 @@ var UserSchema = new mongoose.Schema({
   following: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
   hash: String,
   salt: String
-}, {timestamps: true});
+}, {timestamps: true, usePushEach: true});
 
 UserSchema.plugin(uniqueValidator, {message: 'is already taken.'});
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "jsonwebtoken": "7.1.9",
     "method-override": "2.3.5",
     "methods": "1.1.2",
-    "mongoose": "4.4.10",
+    "mongoose": "4.6.4",
     "mongoose-unique-validator": "1.0.2",
     "morgan": "1.7.0",
     "passport": "0.3.2",


### PR DESCRIPTION
1. В схему статьи добавлено поле `link` с валидацией регулярным выражением. Вывод поля добавлен в метод модели `toJSONfor()`.
2. Исправлена ошибка с модификатором `$pull`: в схемы добавлено `pushForEach: true`.